### PR TITLE
Improve readability of chapter titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Our detailed explanations should help the first type while we hope our checklist
 1. [The Security Checklist](security-checklist.md)
 2. What can go wrong?
 3. Securely transporting stuff: HTTPS explained
-4. I am who I say I am: Authentication  
+4. Authentication: I am who I say I am  
 4.1 Form based authentication  
 4.2 Basic authentication  
 4.3 One is not enough, 2 factor, 3 factor, ....   
 4.4 Why use insecure text messages? Introducing HOTP & TOTP   
 4.5 Handling password resets
-5. What am I allowed to do?: Authorization  
+5. Authorization: What am I allowed to do?  
 5.1 Token based Authorization  
 5.2 OAuth & OAuth2  
 5.3 JWT
-6. Trust no one: User Inputs are evil  
-6.1 Sanitizing Inputs  
+6. Data Validation and Sanitation: Never trust user input  
+6.1 Validating and Sanitizing Inputs  
 6.2 Sanitizing Outputs  
 6.3 Cross Site Scripting  
 6.4 Injection Attacks  
@@ -37,12 +37,12 @@ Our detailed explanations should help the first type while we hope our checklist
 7.2 Encyption  
 7.3 Hashing & One way functions  
 7.4 Hashing speeds cheatsheet
-8. dadada, 123456, cute@123: Passwords  
+8. Passwords: dadada, 123456 and cute@123
 8.1 Password policies  
 8.2 Storing passwords  
 8.3 Life without passwords
 9. Public Key Cryptography
-10. Remember me, please: Handling Sessions  
+10. Sessions: Remember me, please  
 10.1 Where to save state?  
 10.2 Invalidating sessions  
 10.3 Cookie monster & you
@@ -60,7 +60,7 @@ Our detailed explanations should help the first type while we hope our checklist
 12.6 Storing project secrets and passwords in a file    
 12.7 DNS: Of subdomains and forgotten pet-projects  
 12.7 Patching & Updates  
-13. When the bad guys arrive: Attacks  
+13. Attacks: When the bad guys arrive  
 13.1 Clickjacking  
 13.2 Cross Site Request Forgery  
 13.3 Denial of Service  


### PR DESCRIPTION
My humble recommendation. Reversing the traditional order of "title" and "subtitle" as you do is novel but makes it hard to read. It also results in strange punctuation, e.g:

> What am I allowed to do?: Authorization

I also added "validation" to one of the titles because, as [this page](https://vip.wordpress.com/documentation/vip/best-practices/security/validating-sanitizing-escaping/) says, "Sanitation is okay, but validation/rejection is better."

There are other titles that could be better, but this is a start :)