### PR TITLE
Added information about iOS keychain

### DIFF
--- a/security-checklist.md
+++ b/security-checklist.md
@@ -34,7 +34,7 @@
 - [ ] `secret` / `auth token` from 3rd party SDK's should not be hardcoded.
 - [ ] API calls intended to be done `server to server` should not be done from the app.
 - [ ] In Android, all the granted  [permissions](https://developer.android.com/guide/topics/security/permissions.html) should be carefully evaluated.
-- [ ] On iOS, store sensitive information (authentication tokens, API keys, etc.) in the system keychain. Do __bold__not__bold__ store this kind of information in the user defaults.
+- [ ] On iOS, store sensitive information (authentication tokens, API keys, etc.) in the system keychain. Do __not__ store this kind of information in the user defaults.
 - [ ] [Certificate pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) is highly recommended.
 
 

--- a/security-checklist.md
+++ b/security-checklist.md
@@ -34,7 +34,7 @@
 - [ ] `secret` / `auth token` from 3rd party SDK's should not be hardcoded.
 - [ ] API calls intended to be done `server to server` should not be done from the app.
 - [ ] In Android, all the granted  [permissions](https://developer.android.com/guide/topics/security/permissions.html) should be carefully evaluated.
-- [ ] On iOS, store sensitive information (authentication tokens, API keys, etc.) in the system keychain. Do store this kind of information in the user defaults.
+- [ ] On iOS, store sensitive information (authentication tokens, API keys, etc.) in the system keychain. Do __bold__not__bold__ store this kind of information in the user defaults.
 - [ ] [Certificate pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) is highly recommended.
 
 

--- a/security-checklist.md
+++ b/security-checklist.md
@@ -34,6 +34,7 @@
 - [ ] `secret` / `auth token` from 3rd party SDK's should not be hardcoded.
 - [ ] API calls intended to be done `server to server` should not be done from the app.
 - [ ] In Android, all the granted  [permissions](https://developer.android.com/guide/topics/security/permissions.html) should be carefully evaluated.
+- [ ] On iOS, store sensitive information (authentication tokens, API keys, etc.) in the system keychain. Do store this kind of information in the user defaults.
 - [ ] [Certificate pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) is highly recommended.
 
 


### PR DESCRIPTION
Added additional security information for iOS storing of sensitive information. Suggests using the iOS keychain for storing sensitive user information instead of ”user defaults”, which stores preferences in plain text on the file system. 