### PR TITLE
Update security-checklist.md

### DIFF
--- a/security-checklist.md
+++ b/security-checklist.md
@@ -43,7 +43,7 @@
 - [ ] `Add` [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) header to prevent cross site request forgery. Also add [SameSite](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00) attributes on cookies.
 - [ ] `Add` [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) header to prevent SSL stripping attack.
 - [ ] `Add` your domain to the [HSTS Preload List](https://hstspreload.appspot.com/)
-- [ ] `Add` [X-Frame-Options](https://en.wikipedia.org/wiki/Clickjacking#X-Frame-Options) to protect against Clickjacking.
+- [ ] `Add` [frame-ancestors](https://en.wikipedia.org/wiki/Clickjacking#Content_Security_Policy) to protect against Clickjacking.
 - [ ] `Add` [X-XSS-Protection](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#X-XSS-Protection) header to mitigate XSS attacks.
 - [ ] Update DNS records to add [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework) record to mitigate spam and phishing attacks.
 - [ ] Add [subresource integrity checks](https://en.wikipedia.org/wiki/Subresource_Integrity) if loading your JavaScript libraries from a third party CDN. For extra security, add the [require-sri-for](https://w3c.github.io/webappsec-subresource-integrity/#parse-require-sri-for) CSP-directive so you don't load resources that don't have an SRI sat.  


### PR DESCRIPTION
frame-ancestors is in CSP1.1 standard.  "The frame-ancestors directive obsoletes the X-Frame-Options header" (https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options)